### PR TITLE
Debian master

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: lisp
 Priority: extra
 Maintainer: Julián Hernández Gómez <julianhernandez@gmail.com>
 Uploaders: Barak A. Pearlmutter <bap@debian.org>
-Build-Depends: debhelper (>= 9)
+Build-Depends: debhelper (>= 9), emacs-nox
 Standards-Version: 3.9.6
 Homepage: https://github.com/capitaomorte/yasnippet
 


### PR DESCRIPTION
That error when generating the documentation was a problem with some quotes; I don't really get what is the difference between emacs23 and emacs24 in that regard.
