### PR TITLE
sbuild fixes

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+yasnippet (0.9.0~beta1-2) unstable; urgency=medium
+
+  * Fix org-mode-based documentation generation when running with sbuild.
+    The system was trying to access unexistent $HOME directory.
+
+ --
+
 yasnippet (0.9.0~beta1-1) unstable; urgency=medium
 
   * New upstream release

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: yasnippet
 Section: lisp
 Priority: extra
 Maintainer: Julián Hernández Gómez <julianhernandez@gmail.com>
-Uploaders: Barak A. Pearlmutter <bap@debian.org>
+Uploaders: Barak A. Pearlmutter <bap@debian.org>, Alberto Luaces Fernández <aluaces@udc.es>
 Build-Depends: debhelper (>= 9), emacs24-nox | emacs-nox | emacs | emacs24
 Standards-Version: 3.9.6
 Homepage: https://github.com/capitaomorte/yasnippet

--- a/debian/rules
+++ b/debian/rules
@@ -7,4 +7,4 @@
 	dh $@ --parallel
 
 override_dh_auto_build:
-	emacs -Q -L . --batch -l doc/yas-doc-helper.el -f yas--generate-html-batch
+	HOME=$$(pwd) emacs -Q -L . --batch -l doc/yas-doc-helper.el -f yas--generate-html-batch


### PR DESCRIPTION
sbuild revealed that org-mode accesses the home directory when generating the html documentation files.

Reference:

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=682641
